### PR TITLE
OM - 559 | Search with no results

### DIFF
--- a/src/pages/youthProfiles/list/YouthList.module.css
+++ b/src/pages/youthProfiles/list/YouthList.module.css
@@ -40,7 +40,7 @@
 }
 
 .searchResultText {
-    margin-top: 20px;
+    margin: 20px 0;
 }
 
 .dataGrid {

--- a/src/pages/youthProfiles/list/YouthList.tsx
+++ b/src/pages/youthProfiles/list/YouthList.tsx
@@ -134,6 +134,15 @@ const YouthList = () => {
 
       {loading && <Loading />}
 
+      {!loading && queryCount > 0 && (
+        <div className={styles.searchResultText}>
+          {t('youthProfiles.searchResults', {
+            /* eslint-disable @typescript-eslint/camelcase */
+            smart_count: profiles?.length,
+          })}
+        </div>
+      )}
+
       {!loading && profiles.length > 0 && (
         <div className={styles.dataGrid}>
           <Datagrid
@@ -174,15 +183,6 @@ const YouthList = () => {
               label={t('youthProfiles.language')}
             />
           </Datagrid>
-
-          {queryCount > 0 && (
-            <div className={styles.searchResultText}>
-              {t('youthProfiles.searchResults', {
-                /* eslint-disable @typescript-eslint/camelcase */
-                smart_count: profiles?.length,
-              })}
-            </div>
-          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
Moved search results text to be before datagrid. It's original position was inside `profiles.length > 0` check which resulted text not showing with 0 results.