### PR TITLE
YM-81 | Fix save button

### DIFF
--- a/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
@@ -82,3 +82,20 @@ describe('test if approver fields are required', () => {
     expect(errors.approverEmail).toBeFalsy();
   });
 });
+
+test('no empty object in error.primaryAddress when primaryAddress is valid', () => {
+  const errors: ValidationErrors = youthFormValidator({
+    ...values,
+    primaryAddress: {
+      postalCode: '00000',
+      city: 'Helsinki',
+      address: 'Konekuja 6',
+      primary: true,
+      addressType: AddressType.OTHER,
+      countryCode: 'FI',
+      id: '123',
+    },
+  });
+
+  expect(errors.primaryAddress).toBe(undefined);
+});

--- a/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
@@ -97,5 +97,5 @@ test('no empty object in error.primaryAddress when primaryAddress is valid', () 
     },
   });
 
-  expect(errors.primaryAddress).toBe(undefined);
+  expect(errors.primaryAddress).toBeUndefined();
 });

--- a/src/pages/youthProfiles/helpers/youthFormValidator.ts
+++ b/src/pages/youthProfiles/helpers/youthFormValidator.ts
@@ -109,7 +109,9 @@ const isRequiredError = (
         set(primaryAddressError, key, 'validation.required');
       }
     });
-    return primaryAddressError;
+    return Object.keys(primaryAddressError).length > 0
+      ? primaryAddressError
+      : undefined;
   }
 
   return '';


### PR DESCRIPTION
When the user submits the form for creating or editing a youth profile,
the form appears to do nothing.

This was caused by:
1) The validation function always adding the 'primaryAddress' field
   into the error object. If primary address was valid, the value of
   this field was an empty object. Otherwise it contained information
   about sub-field errors.
2) The form submit handler ensuring that the callback function would
   not be called if the the error object had any content (had any
   keys).

This meant that the form would always be in an error state, but in such
a way that the user was not able to detect it, or recover from it.

I fixed this bug by creating an extra conditional that checks if the
'primaryAddress' field has any errors, and only then adds an object for
it in the errors object.