### PR TITLE
YM-61 | Stop non-admin users from accessing admin UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Admin, Resource, useTranslate } from 'react-admin';
+import { Admin, useTranslate } from 'react-admin';
 import { createBrowserHistory as createHistory } from 'history';
 import countries from 'i18n-iso-countries';
 import fi from 'i18n-iso-countries/langs/fi.json';
 
 import i18nProvider from './i18n/i18nProvider';
 import Login from './auth/components/login/Login';
+import ProtectedResource from './auth/components/protectedResource/ProtectedResource';
 import AppRoutes from './routes';
 import authProvider from './auth/authProvider';
 import Dashboard from './pages/dashboard/Dashboard';
@@ -20,6 +21,7 @@ const history = createHistory();
 
 const App: React.FC = () => {
   const t = useTranslate();
+
   return (
     <Admin
       dataProvider={dataProvider}
@@ -31,7 +33,7 @@ const App: React.FC = () => {
       dashboard={Dashboard}
       loginPage={Login}
     >
-      <Resource
+      <ProtectedResource
         name="youthProfiles"
         list={YouthList}
         show={YouthDetails}

--- a/src/auth/api/api.ts
+++ b/src/auth/api/api.ts
@@ -1,0 +1,31 @@
+import client from '../../graphql/client';
+import { hasPermissionQuery } from './queries';
+
+export type RoleResponse = {
+  data: {
+    role: 'admin' | 'none';
+  };
+};
+
+const getRole = async (token: string): Promise<RoleResponse> => {
+  try {
+    await client.query({
+      query: hasPermissionQuery,
+      context: {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    });
+
+    return {
+      data: {
+        role: 'admin',
+      },
+    };
+  } catch (e) {
+    return { data: { role: 'none' } };
+  }
+};
+
+export { getRole };

--- a/src/auth/api/queries.ts
+++ b/src/auth/api/queries.ts
@@ -1,0 +1,13 @@
+import gql from 'graphql-tag';
+
+export const hasPermissionQuery = gql`
+  query Profiles {
+    profiles(serviceType: YOUTH_MEMBERSHIP) {
+      edges {
+        node {
+          id
+        }
+      }
+    }
+  }
+`;

--- a/src/auth/authProvider.ts
+++ b/src/auth/authProvider.ts
@@ -6,6 +6,7 @@ const authProvider: AuthProvider = {
   login: (params) => Promise.resolve(),
   logout: async (params) => {
     localStorage.removeItem('apiToken');
+    localStorage.removeItem('permissions');
     if (Boolean(await userManager.getUser())) {
       return '/logout';
     }
@@ -22,7 +23,11 @@ const authProvider: AuthProvider = {
       ? Promise.resolve()
       : Promise.reject();
   },
-  getPermissions: (params) => Promise.resolve(),
+  getPermissions: () => {
+    const role = localStorage.getItem('permissions');
+
+    return Promise.resolve(role);
+  },
 };
 
 export default authProvider;

--- a/src/auth/components/checkPermissions/CheckPermissions.tsx
+++ b/src/auth/components/checkPermissions/CheckPermissions.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useTranslate } from 'react-admin';
+import { Redirect } from 'react-router';
+
+import useAuthorized from '../../useAuthorized';
+
+type Props = {
+  redirectTo?: string;
+};
+
+// This component is loaded after the user has been logged in. It'll
+// render a placeholder graphic until authorization has been checked.
+//
+// react-admin renders pages optimistically when it comes to
+// authorization. It uses authProvider.getPermissions to attain
+// knowledge of current authorization. In brief, react-admin will render
+// the admin UI before it knows what the result of getPermissions is.
+//
+// If we redirect the user directly into a page that hooks up into the
+// react-admin layout, the admin UI will be flashed to them before the
+// authorization routine is completed. By using this component in a
+// noLayout route, we are able to stop the admin UI from being flashed
+// to users who should not have access.
+const CheckPermissions = ({ redirectTo = '/' }: Props) => {
+  const checkingAuthorization = useAuthorized();
+  const t = useTranslate();
+
+  if (checkingAuthorization) {
+    return <p>{t('oidc.authenticating')}</p>;
+  }
+
+  return <Redirect to={redirectTo} />;
+};
+
+export default CheckPermissions;

--- a/src/auth/components/notAuthorized/NotAuthorized.tsx
+++ b/src/auth/components/notAuthorized/NotAuthorized.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useTranslate, useAuthProvider } from 'react-admin';
+import { Button, Card, CardContent } from '@material-ui/core';
+import { ThemeProvider } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
+import { useHistory } from 'react-router-dom';
+
+import theme from '../../../common/materialUI/themeConfig';
+
+const useStyles = makeStyles({
+  // This styling reproduces the style of the login page.
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: '100vh',
+    height: '1px',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    paddingTop: '6em',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    backgroundImage:
+      'radial-gradient(circle at 50% 14em, #313264 0%, #00023b 60%, #00023b 100%)',
+  },
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    fontWeight: 'bold',
+  },
+  button: {
+    marginTop: '1rem',
+    width: '100%',
+  },
+  description: {
+    maxWidth: '400px',
+    fontWeight: 'normal',
+    lineHeight: 1.4,
+  },
+});
+
+const NotAuthorizedPage: React.FC = () => {
+  const classes = useStyles();
+  const t = useTranslate();
+  const history = useHistory();
+  const authProvider = useAuthProvider();
+
+  const handleLogout = async () => {
+    await authProvider.logout();
+
+    history.push('/logout');
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <div className={classes.main}>
+        <Card>
+          <CardContent>
+            <div className={classes.container}>
+              <p>{t('dashboard.title')}</p>
+              <p className={classes.description}>
+                {t('authorization.notAuthorized')}
+              </p>
+              <Button
+                className={classes.button}
+                variant="contained"
+                color="secondary"
+                onClick={handleLogout}
+              >
+                {t('ra.auth.logout')}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </ThemeProvider>
+  );
+};
+
+export default NotAuthorizedPage;

--- a/src/auth/components/oidcCallback/OidcCallback.tsx
+++ b/src/auth/components/oidcCallback/OidcCallback.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTranslate, useNotify } from 'react-admin';
+import { useTranslate, useNotify, useDataProvider } from 'react-admin';
 import { CallbackComponent } from 'redux-oidc';
 import { User } from 'oidc-client';
 import { RouteChildrenProps } from 'react-router';
@@ -7,21 +7,32 @@ import * as Sentry from '@sentry/browser';
 
 import userManager from '../../userManager';
 import fetchApiToken from '../../fetchApiToken';
+import { RoleResponse } from '../../api/api';
+
+const handleRoleResponse = (roleResponse: RoleResponse) =>
+  roleResponse.data.role;
 
 function OidcCallBack(props: RouteChildrenProps) {
   const t = useTranslate();
   const notify = useNotify();
+  const dataProvider = useDataProvider();
 
-  const onSuccess = (user: User) => {
-    fetchApiToken(user.access_token)
-      .then((apiToken) => {
-        localStorage.setItem('apiToken', apiToken);
-        props.history.push('/');
-      })
-      .catch((error: Error) => {
-        Sentry.captureException(error);
-        notify(t('ra.message.error'), 'warning');
-      });
+  const onSuccess = async (user: User) => {
+    try {
+      const apiToken = await fetchApiToken(user.access_token);
+      const role = handleRoleResponse(await dataProvider.getRole(apiToken));
+
+      localStorage.setItem('apiToken', apiToken);
+      localStorage.setItem('permissions', role);
+
+      // Send user to check permissions in order to allow permissions
+      // checks to complete before asking for react-admin to render its
+      // admin UI.
+      props.history.push('/check-permissions');
+    } catch (error) {
+      Sentry.captureException(error);
+      notify(t('ra.message.error'), 'warning');
+    }
   };
 
   const onError = (error: Error) => {

--- a/src/auth/components/protectedResource/ProtectedResource.tsx
+++ b/src/auth/components/protectedResource/ProtectedResource.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Resource } from 'react-admin';
+import { ResourceProps } from 'ra-core';
+
+import useAuthorized from '../../useAuthorized';
+
+const ProtectedResource = (props: ResourceProps) => {
+  useAuthorized();
+
+  return <Resource {...props} />;
+};
+
+export default ProtectedResource;

--- a/src/auth/components/protectedRoute/ProtectedRoute.tsx
+++ b/src/auth/components/protectedRoute/ProtectedRoute.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Route, RouteProps } from 'react-router';
+import { useAuthenticated } from 'react-admin';
+
+import useAuthorized from '../../useAuthorized';
+
+const ProtectedRoute = (props: RouteProps) => {
+  useAuthenticated();
+  useAuthorized();
+
+  return <Route {...props} />;
+};
+
+export default ProtectedRoute;

--- a/src/auth/useAuthorized.ts
+++ b/src/auth/useAuthorized.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useHistory } from 'react-router';
+import { usePermissions, useAuthState } from 'react-admin';
+
+function useAuthorized(): boolean {
+  const history = useHistory();
+  const { loaded: loadedAuthentication } = useAuthState();
+  const { loaded: loadedPermissions, permissions } = usePermissions();
+
+  const ready =
+    loadedAuthentication &&
+    loadedPermissions &&
+    ['admin', 'none'].includes(permissions);
+
+  useEffect(() => {
+    if (ready && permissions === 'none') {
+      history.push('/not-authorized');
+    }
+  }, [history, permissions, ready]);
+
+  return !ready;
+}
+
+export default useAuthorized;

--- a/src/graphql/dataProvider.ts
+++ b/src/graphql/dataProvider.ts
@@ -11,6 +11,7 @@ import {
   renewYouthProfile,
   updateYouthProfile,
 } from '../pages/youthProfiles/api/YouthApi';
+import { getRole } from '../auth/api/api';
 
 const METHOD_HANDLERS: MethodHandlers = {
   youthProfiles: {
@@ -67,6 +68,7 @@ const dataProvider = {
       return { data };
     }
   },
+  getRole,
 };
 
 export default dataProvider;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -75,5 +75,8 @@
     "ESTONIAN": "Estonian",
     "RUSSIAN": "Russian",
     "SOMALI": "Somali"
+  },
+  "authorization": {
+    "notAuthorized": "You are not authorized to use this system."
   }
 }

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -75,5 +75,8 @@
     "ESTONIAN": "Eesti",
     "RUSSIAN": "Venäjä",
     "SOMALI": "Somali"
+  },
+  "authorization": {
+    "notAuthorized": "Sinulla ei ole oikeuksia käyttää tätä järjestelmää."
   }
 }

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -75,5 +75,8 @@
     "ESTONIAN": "Estniska",
     "RUSSIAN": "Ryska",
     "SOMALI": "Somaliska"
+  },
+  "authorization": {
+    "notAuthorized": "Du har inte behörighet att använda detta system."
   }
 }

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -3,8 +3,12 @@ import { useTranslate } from 'react-admin';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 
+import useAuthorized from '../../auth/useAuthorized';
+
 export default () => {
+  useAuthorized();
   const t = useTranslate();
+
   return (
     <Card>
       <CardHeader title={t('dashboard.title')} />

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,15 +6,33 @@ import CreateYouthProfile from './pages/youthProfiles/create/CreateYouthProfile'
 import EditYouthProfile from './pages/youthProfiles/edit/EditYouthProfile';
 import YouthDetails from './pages/youthProfiles/show/YouthDetails';
 import Logout from './auth/Logout';
+import NotAuthorized from './auth/components/notAuthorized/NotAuthorized';
+import ProtectedRoute from './auth/components/protectedRoute/ProtectedRoute';
+import CheckPermissions from './auth/components/checkPermissions/CheckPermissions';
 
 export default [
-  <Route exact path="/callback" component={OidcCallback} />,
-  <Route exact path="/youthProfiles/create" component={CreateYouthProfile} />,
-  <Route exact path="/youthProfiles/:id/show" component={YouthDetails} />,
-  <Route exact path="/logout" component={Logout} />,
-  <Route
+  <Route exact path="/callback" component={OidcCallback} noLayout />,
+  <ProtectedRoute
+    exact
+    path="/youthProfiles/create"
+    component={CreateYouthProfile}
+  />,
+  <ProtectedRoute
+    exact
+    path="/youthProfiles/:id/show"
+    component={YouthDetails}
+  />,
+  <Route exact path="/logout" component={Logout} noLayout />,
+  <ProtectedRoute
     exact
     path="/youthProfiles/:id/:method"
     component={EditYouthProfile}
+  />,
+  <Route exact path="/not-authorized" component={NotAuthorized} noLayout />,
+  <Route
+    exact
+    path="/check-permissions"
+    component={CheckPermissions}
+    noLayout
   />,
 ];


### PR DESCRIPTION
Previously all users were able to access the admin UI. If they did not
have correct priviledges, they weren't able to fetch data.

After this change those users are no longer able to see the admin UI.
As authentication does not provide information about user
authorization, we are using a protected query to find out if the user
is authorized to use the admin.