### PR TITLE
YM-61 | Optimize permission query

### DIFF
--- a/src/auth/api/queries.ts
+++ b/src/auth/api/queries.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 export const hasPermissionQuery = gql`
   query Profiles {
-    profiles(serviceType: YOUTH_MEMBERSHIP) {
+    profiles(serviceType: YOUTH_MEMBERSHIP, first: 1) {
       edges {
         node {
           id


### PR DESCRIPTION
Previously the permission query fetched a lot of profiles. Here we limit the set into 1.