### PR TITLE
YM-309 | Add youth membership email group to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,8 @@
 Please make your pull requests short, elegant, and only handle one issue at a time! Observe our coding
 practices at https://github.com/City-of-Helsinki/bestpractice/.
 
-<!-- TODO: Uncomment below after we have service email address -->
-<!-- If you make a pull request, you may also want to contact
-<INSERT SERVICE'S ROLE ADDRESS> to tell about your contribution. -->
+If you make a pull request, you may also want to contact 
+kuva-youth-membership-developers@googlegroups.com to tell about your contribution.
  
 Our contribution handling guidelines are at
 https://github.com/City-of-Helsinki/bestpractice/blob/master/accepting-contributions.md


### PR DESCRIPTION
Updated the contribution guidelines so that it contains our developer email group.