### PR TITLE
YM-313 | Change registration max age limit to 29

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -57,7 +57,7 @@
     "phoneMin": "Min length six characters",
     "email": "Invalid email",
     "birthDate": "The birthday should be dd.mm.yyyy.",
-    "ageRestriction": "Only 8-25 years olds can create youth profile."
+    "ageRestriction": "Only 8-29 years olds can create youth profile."
   },
   "notifyMessages": {
     "created": "Youth profile created!",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -57,7 +57,7 @@
     "phoneMin": "Vähimmäispituus kuusi merkkiä",
     "email": "Virheellinen sähköpostiosoite",
     "birthDate": "Syntymäpäivän tulee olla muotoa pp.kk.yyyy.",
-    "ageRestriction": "Palveluun voi rekisteröityä iältään 8-25 vuotiaat."
+    "ageRestriction": "Palveluun voi rekisteröityä iältään 8-29 -vuotiaat."
   },
   "notifyMessages": {
     "created": "Nuorisoprofiili lisätty!",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -57,7 +57,7 @@
     "phoneMin": "Minst sex tecken",
     "email": "Ogiltig e-postadress",
     "birthDate": "Födelsedagen bör vara dd.mm.yyyy.",
-    "ageRestriction": "Endast 8-25 år kan skapa ungdomsprofil."
+    "ageRestriction": "Endast 8-29 år kan skapa ungdomsprofil."
   },
   "notifyMessages": {
     "created": "Ungdomsprofil skapad!",

--- a/src/pages/youthProfiles/constants/youthProfileConstants.ts
+++ b/src/pages/youthProfiles/constants/youthProfileConstants.ts
@@ -1,7 +1,7 @@
 export default {
   PROFILE_CREATION: {
     AGE_MIN: 8,
-    AGE_MAX: 25,
+    AGE_MAX: 29,
     AGE_ADULT: 18,
     EMAIL_REGEX: /\S+@\S+\.\S+/,
   },


### PR DESCRIPTION
I changed the max age of the service to 29 via configuration and changed the corresponding validation error messages.