### PR TITLE
YM-323 | Fix OIDC_CLIENT_ID in production CI configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ build-production:
     DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'production'
     DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: "https://api.hel.fi/sso/"
     DOCKER_BUILD_ARG_REACT_APP_PROFILE_GRAPHQL: "https://api.hel.fi/profiili/graphql/"
-    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://id.hel.fi/auth/clients/jassariui-prod"
+    DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: "https://id.hel.fi/auth/clients/jassari-admin-prod"
     DOCKER_BUILD_ARG_REACT_APP_BASE_URL: "https://jassari-admin.hel.fi/"
   only:
     refs:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "youth-membership-admin-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "@sentry/browser": "^5.18.0",


### PR DESCRIPTION
OIDC_CLIENT_ID was changed earlier to use the public Youth membership UI's
id. I fixed this so that it's now correct.

Bumped the package version to 1.0.1.