### PR TITLE
YM-21, YM-13 | Allow youth admins to control additional contact persons

### DIFF
--- a/src/auth/api/queries.ts
+++ b/src/auth/api/queries.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const hasPermissionQuery = gql`
-  query Profiles {
+  query HasPermission {
     profiles(serviceType: YOUTH_MEMBERSHIP, first: 1) {
       edges {
         node {

--- a/src/graphql/generatedTypes.ts
+++ b/src/graphql/generatedTypes.ts
@@ -4,6 +4,51 @@
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL query operation: HasPermission
+// ====================================================
+
+export interface HasPermission_profiles_edges_node {
+  /**
+   * The ID of the object.
+   */
+  readonly id: string;
+}
+
+export interface HasPermission_profiles_edges {
+  /**
+   * The item at the end of the edge
+   */
+  readonly node: HasPermission_profiles_edges_node | null;
+}
+
+export interface HasPermission_profiles {
+  /**
+   * Contains the nodes in this connection.
+   */
+  readonly edges: ReadonlyArray<(HasPermission_profiles_edges | null)>;
+}
+
+export interface HasPermission {
+  /**
+   * Search for profiles. The results are filtered based on the given parameters. The results are paged using Relay.
+   * 
+   * Requires `staff` credentials for the service given in `serviceType`. The
+   * profiles must have an active connection to the given `serviceType`, otherwise
+   * they will not be returned.
+   * 
+   * Possible error codes:
+   * 
+   * * `TODO`
+   */
+  readonly profiles: HasPermission_profiles | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: Profiles
 // ====================================================
 
@@ -149,6 +194,31 @@ export interface Profile_profile_primaryEmail {
   readonly id: string;
 }
 
+export interface Profile_profile_youthProfile_additionalContactPersons_edges_node {
+  /**
+   * The ID of the object.
+   */
+  readonly id: string;
+  readonly firstName: string;
+  readonly lastName: string;
+  readonly phone: string;
+  readonly email: string;
+}
+
+export interface Profile_profile_youthProfile_additionalContactPersons_edges {
+  /**
+   * The item at the end of the edge
+   */
+  readonly node: Profile_profile_youthProfile_additionalContactPersons_edges_node | null;
+}
+
+export interface Profile_profile_youthProfile_additionalContactPersons {
+  /**
+   * Contains the nodes in this connection.
+   */
+  readonly edges: ReadonlyArray<(Profile_profile_youthProfile_additionalContactPersons_edges | null)>;
+}
+
 export interface Profile_profile_youthProfile {
   readonly expiration: any;
   readonly birthDate: any;
@@ -175,6 +245,7 @@ export interface Profile_profile_youthProfile {
    * Tells if the membership is currently renewable or not
    */
   readonly renewable: boolean | null;
+  readonly additionalContactPersons: Profile_profile_youthProfile_additionalContactPersons;
 }
 
 export interface Profile_profile {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,7 +48,9 @@
     "searchResults": "Search found %{smart_count} result |||| Search found %{smart_count} results",
     "makePrimaryAddress": "Make into primary address",
     "removeAddress": "Remove",
-    "addAnotherAddress": "Add another address"
+    "addAnotherAddress": "Add another address",
+    "removeAdditionalContactPerson": "Remove",
+    "addAdditionalContactPerson": "Add another guardian"
   },
   "validation": {
     "tooLong": "Too long",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -48,7 +48,9 @@
     "searchResults": "Haulla löytyi %{smart_count} tulos |||| Haulla löytyi %{smart_count} tulosta",
     "makePrimaryAddress": "Muuta ensisijaiseksi osoitteeksi",
     "removeAddress": "Poista",
-    "addAnotherAddress": "Lisää toinen osoite"
+    "addAnotherAddress": "Lisää toinen osoite",
+    "removeAdditionalContactPerson": "Poista",
+    "addAdditionalContactPerson": "Lisää toinen huoltaja"
   },
   "validation": {
     "tooLong": "Liian pitkä",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -47,8 +47,10 @@
     "renew": "Förnya medlemskape",
     "searchResults": "Sökningen hittade ett resultat |||| Sökningen hittade %{smart_count} resultat",
     "makePrimaryAddress": "Gör till primäradress",
-    "removeAddress": "Poista",
-    "addAnotherAddress": "Lisää toinen osoite"
+    "removeAddress": "Avlägsna",
+    "addAnotherAddress": "Lägg till en annan adress",
+    "removeAdditionalContactPerson": "Avlägsna",
+    "addAdditionalContactPerson": "Lägg till en annan vårdnadshavare"
   },
   "validation": {
     "tooLong": "För lång",

--- a/src/pages/youthProfiles/edit/EditYouthProfile.tsx
+++ b/src/pages/youthProfiles/edit/EditYouthProfile.tsx
@@ -12,6 +12,7 @@ import { useParams, useHistory, useLocation } from 'react-router';
 import YouthProfileForm from '../form/YouthProfileForm';
 import { FormValues } from '../types/youthProfileTypes';
 import getAddressesFromNode from '../helpers/getAddressesFromNode';
+import getAdditionalContactPersons from '../helpers/getAdditionalContactPersons';
 
 type Params = {
   id?: string;
@@ -41,7 +42,9 @@ const EditYouthProfile: React.FC = () => {
 
   if (loading) return <Loading />;
   if (!loading && error) return <Error error={error} />;
+
   const profile = data?.data?.profile;
+  const additionalContactPersons = getAdditionalContactPersons(profile);
 
   const handleSave = (values: FormValues) => {
     update(
@@ -92,6 +95,7 @@ const EditYouthProfile: React.FC = () => {
         approverLastName: profile.youthProfile.approverLastName,
         approverEmail: profile.youthProfile.approverEmail,
         approverPhone: profile.youthProfile.approverPhone,
+        additionalContactPersons,
       }}
     />
   );

--- a/src/pages/youthProfiles/form/YouthProfileArrayField.tsx
+++ b/src/pages/youthProfiles/form/YouthProfileArrayField.tsx
@@ -1,0 +1,77 @@
+import React, { ReactNode } from 'react';
+import { FieldArray } from 'react-final-form-arrays';
+import { Button, IconPlusCircle } from 'hds-react';
+
+import styles from './youthProfileArrayField.module.css';
+
+type Props = {
+  name: string;
+  renderField: (name: string, index: number) => ReactNode;
+  addItemLabel: string;
+  removeItemLabel: string;
+  onPushItem: (push: (value: unknown) => void) => unknown;
+  additionalFieldControls?: Array<{
+    label: string;
+    onClick: (index: number) => void;
+  }>;
+};
+
+function YouthProfileArrayField({
+  name,
+  renderField,
+  addItemLabel,
+  removeItemLabel,
+  onPushItem,
+  additionalFieldControls,
+}: Props) {
+  return (
+    <FieldArray name={name}>
+      {({ fields }) => (
+        <div className={[styles.stack, styles.l].join(' ')}>
+          {fields.value.length > 0 && (
+            <div className={[styles.stack, styles.m].join(' ')}>
+              {fields.map((name: string, index: number) => (
+                <div key={name}>
+                  {renderField(name, index)}
+                  <div>
+                    <button
+                      type="button"
+                      className={styles.additionalActionButton}
+                      onClick={() => fields.remove(index)}
+                    >
+                      {removeItemLabel}
+                    </button>
+                    {additionalFieldControls &&
+                      additionalFieldControls.map((fieldControl) => (
+                        <button
+                          key={fieldControl.label}
+                          type="button"
+                          className={styles.additionalActionButton}
+                          onClick={() => fieldControl.onClick(index)}
+                        >
+                          {fieldControl.label}
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <Button
+            type="button"
+            iconLeft={<IconPlusCircle />}
+            variant="supplementary"
+            className={styles.addItemButton}
+            onClick={() => {
+              onPushItem(fields.push);
+            }}
+          >
+            {addItemLabel}
+          </Button>
+        </div>
+      )}
+    </FieldArray>
+  );
+}
+
+export default YouthProfileArrayField;

--- a/src/pages/youthProfiles/form/YouthProfileForm.module.css
+++ b/src/pages/youthProfiles/form/YouthProfileForm.module.css
@@ -38,17 +38,8 @@
   margin-left: 20px;
 }
 
-.makePrimaryAddressButton {
-  margin-left: var(--spacing-m);
-}
-
 .fieldGroup {
   margin: var(--spacing-l) 0 var(--spacing-m);
-}
-
-.addButton {
-  margin-left: calc(-1 * var(--spacing-m));
-  margin-bottom: var(--spacing-l);
 }
 
 .addressRowContainer {
@@ -71,8 +62,4 @@
   .addressRowContainer > *:nth-child(1) {
     margin-bottom: 0;
   }
-}
-
-.arrayItemControl {
-  margin-top: var(--spacing-xs);
 }

--- a/src/pages/youthProfiles/form/YouthProfileForm.tsx
+++ b/src/pages/youthProfiles/form/YouthProfileForm.tsx
@@ -407,8 +407,10 @@ const YouthProfileForm = (props: Props) => {
                     </div>
                   </>
                 )}
-                addItemLabel={t('youthProfiles.addAnotherAddress')}
-                removeItemLabel={t('youthProfiles.removeAddress')}
+                addItemLabel={t('youthProfiles.addAdditionalContactPerson')}
+                removeItemLabel={t(
+                  'youthProfiles.removeAdditionalContactPerson'
+                )}
                 onPushItem={(push) => {
                   push({
                     firstName: '',

--- a/src/pages/youthProfiles/form/YouthProfileForm.tsx
+++ b/src/pages/youthProfiles/form/YouthProfileForm.tsx
@@ -9,8 +9,6 @@ import {
 import { useFormState, FormRenderProps } from 'react-final-form';
 import { useHistory, useParams } from 'react-router';
 import countries from 'i18n-iso-countries';
-import { FieldArray } from 'react-final-form-arrays';
-import { Button, IconPlusCircle } from 'hds-react';
 
 import styles from './YouthProfileForm.module.css';
 import {
@@ -26,6 +24,7 @@ import { FormValues } from '../types/youthProfileTypes';
 import youthFormValidator, {
   ValidationErrors,
 } from '../helpers/youthFormValidator';
+import YouthProfileArrayField from './YouthProfileArrayField';
 
 type Props = {
   record?: FormValues;
@@ -192,86 +191,63 @@ const YouthProfileForm = (props: Props) => {
               />
             </div>
 
-            <FieldArray name="addresses">
-              {({ fields }) => (
-                <React.Fragment>
-                  {fields.map((name, index) => (
-                    <div key={index} className={styles.fieldGroup}>
-                      <div className={styles.rowContainer}>
-                        <SelectInput
-                          name={`${name}.countryCode`}
-                          labelText={t('youthProfiles.country')}
-                          options={countryOptions}
-                          className={styles.select}
-                        />
-                      </div>
-
-                      <div
-                        className={[
-                          styles.addressRowContainer,
-                          styles.rowContainer,
-                        ].join(' ')}
-                      >
-                        <TextInput
-                          name={`${name}.address`}
-                          label={t('youthProfiles.streetAddress')}
-                          className={styles.textField}
-                          error={errors.addresses?.[index]?.address}
-                        />
-                        <TextInput
-                          name={`${name}.postalCode`}
-                          label={t('youthProfiles.postalCode')}
-                          className={styles.textField}
-                          error={errors.addresses?.[index]?.postalCode}
-                        />
-                        <TextInput
-                          name={`${name}.city`}
-                          label={t('youthProfiles.city')}
-                          className={styles.textField}
-                          error={errors.addresses?.[index]?.city}
-                        />
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => fields.remove(index)}
-                        className={styles.arrayItemControl}
-                      >
-                        {t('youthProfiles.removeAddress')}
-                      </button>
-                      <button
-                        type="button"
-                        className={[
-                          styles.arrayItemControl,
-                          styles.makePrimaryAddressButton,
-                        ].join(' ')}
-                        onClick={() =>
-                          handleMakePrimary(formRenderProps, index)
-                        }
-                      >
-                        {t('youthProfiles.makePrimaryAddress')}
-                      </button>
-                    </div>
-                  ))}
-                  <Button
-                    variant="supplementary"
-                    iconLeft={<IconPlusCircle />}
-                    className={styles.addButton}
-                    type="button"
-                    onClick={() =>
-                      fields.push({
-                        address: '',
-                        postalCode: '',
-                        city: '',
-                        countryCode: 'FI',
-                        primary: false,
-                      })
-                    }
+            <YouthProfileArrayField
+              name="addresses"
+              renderField={(name, index) => (
+                <>
+                  <div className={styles.rowContainer}>
+                    <SelectInput
+                      name={`${name}.countryCode`}
+                      labelText={t('youthProfiles.country')}
+                      options={countryOptions}
+                      className={styles.select}
+                    />
+                  </div>
+                  <div
+                    className={[
+                      styles.addressRowContainer,
+                      styles.rowContainer,
+                    ].join(' ')}
                   >
-                    {t('youthProfiles.addAnotherAddress')}
-                  </Button>
-                </React.Fragment>
+                    <TextInput
+                      name={`${name}.address`}
+                      label={t('youthProfiles.streetAddress')}
+                      className={styles.textField}
+                      error={errors.addresses?.[index]?.address}
+                    />
+                    <TextInput
+                      name={`${name}.postalCode`}
+                      label={t('youthProfiles.postalCode')}
+                      className={styles.textField}
+                      error={errors.addresses?.[index]?.postalCode}
+                    />
+                    <TextInput
+                      name={`${name}.city`}
+                      label={t('youthProfiles.city')}
+                      className={styles.textField}
+                      error={errors.addresses?.[index]?.city}
+                    />
+                  </div>
+                </>
               )}
-            </FieldArray>
+              additionalFieldControls={[
+                {
+                  label: t('youthProfiles.makePrimaryAddress'),
+                  onClick: (index) => handleMakePrimary(formRenderProps, index),
+                },
+              ]}
+              addItemLabel={t('youthProfiles.addAnotherAddress')}
+              removeItemLabel={t('youthProfiles.removeAddress')}
+              onPushItem={(push) => {
+                push({
+                  address: '',
+                  postalCode: '',
+                  city: '',
+                  countryCode: 'FI',
+                  primary: false,
+                });
+              }}
+            />
 
             <div className={styles.rowContainer}>
               <TextInput

--- a/src/pages/youthProfiles/form/YouthProfileForm.tsx
+++ b/src/pages/youthProfiles/form/YouthProfileForm.tsx
@@ -138,6 +138,7 @@ const YouthProfileForm = (props: Props) => {
           primary: true,
         },
         addresses: [],
+        additionalContactPersons: [],
       }}
       record={props.record}
       render={(formRenderProps: FormRenderProps<FormValues>) => (
@@ -363,6 +364,59 @@ const YouthProfileForm = (props: Props) => {
                 name="approverPhone"
                 className={styles.textField}
                 error={errors.approverPhone}
+              />
+            </div>
+            <div className={styles.rowContainer}>
+              <YouthProfileArrayField
+                name="additionalContactPersons"
+                renderField={(name, index) => (
+                  <>
+                    <div className={styles.rowContainer}>
+                      <TextInput
+                        label={t('youthProfiles.firstName')}
+                        name={`${name}.firstName`}
+                        className={styles.textField}
+                        error={
+                          errors.additionalContactPersons?.[index]?.firstName
+                        }
+                      />
+
+                      <TextInput
+                        label={t('youthProfiles.lastName')}
+                        name={`${name}.lastName`}
+                        className={styles.textField}
+                        error={
+                          errors.additionalContactPersons?.[index]?.lastName
+                        }
+                      />
+                    </div>
+                    <div className={styles.rowContainer}>
+                      <TextInput
+                        label={t('youthProfiles.email')}
+                        name={`${name}.email`}
+                        className={styles.textField}
+                        error={errors.additionalContactPersons?.[index]?.email}
+                      />
+
+                      <TextInput
+                        label={t('youthProfiles.phone')}
+                        name={`${name}.phone`}
+                        className={styles.textField}
+                        error={errors.additionalContactPersons?.[index]?.phone}
+                      />
+                    </div>
+                  </>
+                )}
+                addItemLabel={t('youthProfiles.addAnotherAddress')}
+                removeItemLabel={t('youthProfiles.removeAddress')}
+                onPushItem={(push) => {
+                  push({
+                    firstName: '',
+                    lastName: '',
+                    phone: '',
+                    email: '',
+                  });
+                }}
               />
             </div>
             <Toolbar>

--- a/src/pages/youthProfiles/form/youthProfileArrayField.module.css
+++ b/src/pages/youthProfiles/form/youthProfileArrayField.module.css
@@ -1,0 +1,18 @@
+.stack {
+  display: grid;
+  grid-template-columns: 1fr;
+  row-gap: var(--spacing-m);
+}
+
+.addItemButton {
+  margin-left: calc(-1 * var(--spacing-m));
+  margin-bottom: var(--spacing-l);
+  width: fit-content;
+}
+
+.additionalActionButton {
+  margin-top: var(--spacing-xs);
+}
+.additionalActionButton:not(:first-child) {
+  margin-left: var(--spacing-m);;
+}

--- a/src/pages/youthProfiles/helpers/__tests__/prepareArrayFieldChanges.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/prepareArrayFieldChanges.test.ts
@@ -1,0 +1,29 @@
+import prepareArrayFieldChanges from '../prepareArrayFieldChanges';
+
+describe('prepareArrayFieldChanges', () => {
+  it('should correctly determine added, updated and removed items', () => {
+    const item0 = {
+      id: '0',
+      name: 'One',
+    };
+    const item0b = {
+      ...item0,
+      name: 'One2',
+    };
+    const item1 = {
+      id: '1',
+      name: 'Two',
+    };
+    const item2 = {
+      name: 'Three',
+    };
+    const { add, update, remove } = prepareArrayFieldChanges(
+      [item0, item1],
+      [item0b, item2]
+    );
+
+    expect(add).toEqual([item2]);
+    expect(update).toEqual([item0b]);
+    expect(remove).toEqual([item1].map((item) => item.id));
+  });
+});

--- a/src/pages/youthProfiles/helpers/__tests__/utils.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/utils.test.ts
@@ -46,6 +46,9 @@ const defaultProfile: Profile = {
     expiration: '2020-07-31',
     membershipStatus: MembershipStatus.ACTIVE,
     renewable: false,
+    additionalContactPersons: {
+      edges: [],
+    },
   },
 };
 

--- a/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
@@ -31,6 +31,7 @@ const values: Values = {
   approverLastName: '',
   approverEmail: 'incorrect.email',
   approverPhone: '',
+  additionalContactPersons: [],
 };
 
 test('test validation functionality', () => {
@@ -98,4 +99,52 @@ test('no empty object in error.primaryAddress when primaryAddress is valid', () 
   });
 
   expect(errors.primaryAddress).toBeUndefined();
+});
+
+describe('additional contact person validation', () => {
+  test('all fields are required for additional contact person', () => {
+    const errors: ValidationErrors = youthFormValidator({
+      ...values,
+      additionalContactPersons: [
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        {
+          firstName: null,
+          lastName: null,
+          phone: null,
+          email: null,
+        },
+      ],
+    });
+
+    expect(errors.additionalContactPersons?.[0].firstName).toEqual(
+      'validation.required'
+    );
+    expect(errors.additionalContactPersons?.[0].lastName).toEqual(
+      'validation.required'
+    );
+    expect(errors.additionalContactPersons?.[0].phone).toEqual(
+      'validation.required'
+    );
+    expect(errors.additionalContactPersons?.[0].email).toEqual(
+      'validation.required'
+    );
+  });
+
+  test('email needs to be an email', () => {
+    const errors: ValidationErrors = youthFormValidator({
+      ...values,
+      additionalContactPersons: [
+        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+        // @ts-ignore
+        {
+          email: 'not email like',
+        },
+      ],
+    });
+
+    expect(errors.additionalContactPersons?.[0].email).toEqual(
+      'validation.email'
+    );
+  });
 });

--- a/src/pages/youthProfiles/helpers/getAdditionalContactPersons.ts
+++ b/src/pages/youthProfiles/helpers/getAdditionalContactPersons.ts
@@ -1,0 +1,32 @@
+import {
+  Profile_profile as Profile,
+  Profile_profile_youthProfile_additionalContactPersons_edges_node as YouthProfileAdditionalContactPersonNode,
+  UpdateAdditionalContactPersonInput,
+} from '../../../graphql/generatedTypes';
+
+function getAdditionalContactPersons(
+  profile?: Profile | null
+): UpdateAdditionalContactPersonInput[] {
+  const additionalContactPersons =
+    profile?.youthProfile?.additionalContactPersons.edges;
+
+  if (!additionalContactPersons) {
+    return [];
+  }
+
+  return additionalContactPersons
+    .map((contactPerson) => contactPerson?.node)
+    .filter((contactPerson): contactPerson is Exclude<
+      YouthProfileAdditionalContactPersonNode,
+      null
+    > => Boolean(contactPerson))
+    .map((contactPerson) => ({
+      id: contactPerson.id,
+      firstName: contactPerson.firstName,
+      lastName: contactPerson.lastName,
+      phone: contactPerson.phone,
+      email: contactPerson.email,
+    }));
+}
+
+export default getAdditionalContactPersons;

--- a/src/pages/youthProfiles/helpers/prepareArrayFieldChanges.ts
+++ b/src/pages/youthProfiles/helpers/prepareArrayFieldChanges.ts
@@ -1,0 +1,47 @@
+type Model = { id: string };
+
+type ArrayFieldChanges<Add, Update, Remove> = {
+  add: Add;
+  update: Update;
+  remove: Remove;
+};
+
+// In the form we just have an array of models. But when we send them to
+// the API, we have to distinct between new ones, ones that are updates
+// and ones that are being removed.
+
+// Form data model
+// model: [
+//     {...}
+// ]
+
+// API data model
+// addModel: [...],
+// updateModel: [...],
+// removeModel: [...],
+
+// So this function uses the previous values and the next values to
+// understand which model is new, which is updated and which is removed.
+function prepareArrayFieldChanges<C, U extends Model>(
+  current: U[],
+  next: Array<U | C>
+): ArrayFieldChanges<C[], U[], string[]> {
+  const add = next.filter((model): model is C => !('id' in model));
+  const update = next.filter((model): model is U => 'id' in model);
+  const nextIds = next
+    .filter(
+      (model): model is U => 'id' in model && typeof model.id === 'string'
+    )
+    .map((model) => model.id);
+  const remove = current
+    .filter((model) => !nextIds.includes(model.id))
+    .map((model) => model.id);
+
+  return {
+    add,
+    update,
+    remove,
+  };
+}
+
+export default prepareArrayFieldChanges;

--- a/src/pages/youthProfiles/helpers/youthFormValidator.ts
+++ b/src/pages/youthProfiles/helpers/youthFormValidator.ts
@@ -8,6 +8,8 @@ import {
   Profile_profile_addresses_edges_node as Address,
   Profile_profile_primaryAddress as PrimaryAddress,
   YouthLanguage,
+  CreateAdditionalContactPersonInput,
+  UpdateAdditionalContactPersonInput,
 } from '../../../graphql/generatedTypes';
 import youthProfileConstants from '../constants/youthProfileConstants';
 
@@ -32,6 +34,12 @@ const APPROVAL_FIELDS = [
 ];
 
 const REQUIRED_ADDRESS_FIELDS = ['address', 'postalCode', 'city'];
+const REQUIRED_ADDITIONAL_CONTACT_PERSON_FIELDS = [
+  'firstName',
+  'lastName',
+  'phone',
+  'email',
+];
 
 const EMAIL_FIELDS = ['email', 'approverEmail'];
 
@@ -39,6 +47,17 @@ type AddressError = {
   address?: string;
   postalCode?: string;
   city?: string;
+};
+
+type AdditionalContactPerson =
+  | CreateAdditionalContactPersonInput
+  | UpdateAdditionalContactPersonInput;
+
+type AdditionalContactPersonError = {
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  email?: string;
 };
 
 export type ValidationErrors = {
@@ -58,6 +77,7 @@ export type ValidationErrors = {
   approverLastName?: string;
   approverEmail?: string;
   approverPhone?: string;
+  additionalContactPersons?: AdditionalContactPersonError[];
 };
 
 type LengthOptions = {
@@ -87,28 +107,52 @@ const checkAgeDateString = (dateString: string) => {
   return day.length > 0 && month.length > 0 && year.length > 0;
 };
 
-const getAddressRequiredError = (
-  address: Address | PrimaryAddress
-): AddressError | null => {
-  const addressError = {};
+function validateObject<T extends object>(
+  object: T,
+  fields: string[]
+  // This type (attempts) implies an object whose keys can be found
+  // from object T. Not all of T's keys must be present, but if the key
+  // is present, its value is of type string.
+): { [K in keyof T]?: string } | null {
+  const error = {};
 
-  (Object.keys(address) as Array<keyof typeof address>).forEach((key) => {
-    if (REQUIRED_ADDRESS_FIELDS.includes(key) && !address[key]) {
-      set(addressError, key, 'validation.required');
+  (Object.keys(object) as Array<keyof typeof object>).forEach((key) => {
+    if (fields.includes(key.toString()) && !object[key]) {
+      set(error, key, 'validation.required');
+    } else if (
+      EMAIL_FIELDS.includes(key.toString()) &&
+      !Validator.isEmail((object[key] as unknown) as string)
+    ) {
+      set(error, key, 'validation.email');
     }
   });
 
-  if (Object.keys(addressError).length > 0) {
-    return addressError;
+  if (Object.keys(error).length > 0) {
+    return error;
   }
 
   return null;
+}
+
+const getAddressRequiredError = (
+  address: Address | PrimaryAddress
+): AddressError | null => {
+  return validateObject(address, REQUIRED_ADDRESS_FIELDS);
+};
+
+const getContactPersonRequiredError = (
+  additionalContactPerson: AdditionalContactPerson
+): AdditionalContactPersonError | null => {
+  return validateObject(
+    additionalContactPerson,
+    REQUIRED_ADDITIONAL_CONTACT_PERSON_FIELDS
+  );
 };
 
 const isRequiredError = (
   field: keyof FormValues,
-  value: string | PrimaryAddress | Address[]
-): string | AddressError | AddressError[] => {
+  value: string | PrimaryAddress | Address[] | AdditionalContactPerson[]
+): string | AddressError | AddressError[] | AdditionalContactPersonError[] => {
   // If value is included in APPROVER_FIELDS return, these are validated later
   if (APPROVAL_FIELDS.includes(field)) return '';
   if (
@@ -120,22 +164,28 @@ const isRequiredError = (
     return 'validation.required';
   }
 
-  if (
-    field === 'primaryAddress' &&
-    typeof value !== 'string' &&
-    !Array.isArray(value)
-  ) {
-    return getAddressRequiredError(value) || '';
+  if (field === 'primaryAddress') {
+    const castValue = value as PrimaryAddress;
+
+    return getAddressRequiredError(castValue) || '';
   }
 
-  if (
-    field === 'addresses' &&
-    typeof value !== 'string' &&
-    Array.isArray(value)
-  ) {
-    return value
+  if (field === 'addresses') {
+    const castValue = value as Address[];
+
+    return castValue
       .map((address) => getAddressRequiredError(address))
       .filter((error): error is AddressError => error !== null);
+  }
+
+  if (field === 'additionalContactPersons') {
+    const castValue = value as AdditionalContactPerson[];
+
+    return castValue
+      .map((additionalContactPerson) =>
+        getContactPersonRequiredError(additionalContactPerson)
+      )
+      .filter((error): error is AdditionalContactPersonError => error !== null);
   }
 
   return '';

--- a/src/pages/youthProfiles/query/YouthProfileQueries.ts
+++ b/src/pages/youthProfiles/query/YouthProfileQueries.ts
@@ -84,6 +84,17 @@ export const profileQuery = gql`
         approverEmail
         approverPhone
         renewable
+        additionalContactPersons {
+          edges {
+            node {
+              id
+              firstName
+              lastName
+              phone
+              email
+            }
+          }
+        }
       }
     }
   }

--- a/src/pages/youthProfiles/types/youthProfileTypes.ts
+++ b/src/pages/youthProfiles/types/youthProfileTypes.ts
@@ -3,7 +3,13 @@ import {
   YouthLanguage,
   Profile_profile_primaryAddress as PrimaryAddress,
   Profile_profile_addresses_edges_node as Address,
+  CreateAdditionalContactPersonInput,
+  UpdateAdditionalContactPersonInput,
 } from '../../../graphql/generatedTypes';
+
+type AdditionalContactPerson =
+  | CreateAdditionalContactPersonInput
+  | UpdateAdditionalContactPersonInput;
 
 type Index =
   | 'firstName'
@@ -20,7 +26,8 @@ type Index =
   | 'approverFirstName'
   | 'approverLastName'
   | 'approverEmail'
-  | 'approverPhone';
+  | 'approverPhone'
+  | 'additionalContactPerson';
 
 export type Values = {
   firstName: string;
@@ -39,6 +46,7 @@ export type Values = {
   approverLastName: string;
   approverEmail: string;
   approverPhone: string;
+  additionalContactPersons: AdditionalContactPerson[];
 };
 
 export type Errors = {
@@ -78,4 +86,5 @@ export type FormValues = {
   approverLastName: string;
   approverEmail: string;
   approverPhone: string;
+  additionalContactPersons: AdditionalContactPerson[];
 };


### PR DESCRIPTION
Youth admins can control additional contact persons when adding a new youth, or when editing one. Validation, prefilling etc. should work.

I've tested this with a few unit tests for the validator because it's so complex. I also added a simple smoke test for the `prepareArrayField` because it may be hard tounderstand.

I didn't add more tests because they should likely be implemented through `e2e`.