### PR TITLE
YM-21 | Fix array validation

### DIFF
--- a/src/pages/youthProfiles/form/YouthProfileForm.tsx
+++ b/src/pages/youthProfiles/form/YouthProfileForm.tsx
@@ -49,7 +49,7 @@ const YouthProfileForm = (props: Props) => {
   const params: Params = useParams();
 
   const onSave = (values: FormValues) => {
-    const nextErrors: ValidationErrors = youthFormValidator(values);
+    const nextErrors = youthFormValidator(values);
     setErrors(nextErrors);
 
     if (Object.keys(nextErrors).length === 0) {

--- a/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
@@ -106,6 +106,12 @@ describe('additional contact person validation', () => {
     const errors: ValidationErrors = youthFormValidator({
       ...values,
       additionalContactPersons: [
+        {
+          firstName: 'Jocelyn',
+          lastName: 'Wu',
+          phone: '000000000',
+          email: 'fake@email.com',
+        },
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         {
@@ -117,16 +123,16 @@ describe('additional contact person validation', () => {
       ],
     });
 
-    expect(errors.additionalContactPersons?.[0].firstName).toEqual(
+    expect(errors.additionalContactPersons?.[1].firstName).toEqual(
       'validation.required'
     );
-    expect(errors.additionalContactPersons?.[0].lastName).toEqual(
+    expect(errors.additionalContactPersons?.[1].lastName).toEqual(
       'validation.required'
     );
-    expect(errors.additionalContactPersons?.[0].phone).toEqual(
+    expect(errors.additionalContactPersons?.[1].phone).toEqual(
       'validation.required'
     );
-    expect(errors.additionalContactPersons?.[0].email).toEqual(
+    expect(errors.additionalContactPersons?.[1].email).toEqual(
       'validation.required'
     );
   });

--- a/src/pages/youthProfiles/show/YouthDetails.tsx
+++ b/src/pages/youthProfiles/show/YouthDetails.tsx
@@ -230,6 +230,7 @@ const YouthDetails = (props: ReactAdminComponentPropsWithId) => {
       />
       {additionalContactPersons.map(({ firstName, lastName, phone, email }) => (
         <Approver
+          key={[firstName, lastName, phone, email].join('')}
           name={[firstName, lastName].join(' ')}
           email={email}
           phone={phone}


### PR DESCRIPTION
Previously a valid item in an array would be represented by nothing. Only invalid items would cause new items to be added into an array. This meant that invalid items' errors would be matched incorrectly in the view layer if that item was preceded by valid items.