### PR TITLE
YM-21 | Fix multiple guardian validation.

### DIFF
--- a/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
+++ b/src/pages/youthProfiles/helpers/__tests__/youthFormValidator.test.ts
@@ -70,7 +70,7 @@ describe('test if approver fields are required', () => {
     expect(errors.approverFirstName).toEqual('validation.required');
     expect(errors.approverLastName).toEqual('validation.required');
     expect(errors.approverPhone).toEqual('validation.required');
-    expect(errors.approverEmail).toEqual('validation.required');
+    expect(errors.approverEmail).toEqual('validation.email');
   });
 
   test('user is adult', () => {
@@ -115,10 +115,10 @@ describe('additional contact person validation', () => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
         {
-          firstName: null,
-          lastName: null,
-          phone: null,
-          email: null,
+          firstName: '',
+          lastName: '',
+          phone: '',
+          email: '',
         },
       ],
     });
@@ -133,7 +133,7 @@ describe('additional contact person validation', () => {
       'validation.required'
     );
     expect(errors.additionalContactPersons?.[1].email).toEqual(
-      'validation.required'
+      'validation.email'
     );
   });
 

--- a/src/pages/youthProfiles/helpers/youthFormValidator.ts
+++ b/src/pages/youthProfiles/helpers/youthFormValidator.ts
@@ -117,7 +117,12 @@ function validateObject<T extends object>(
   const error = {};
 
   (Object.keys(object) as Array<keyof typeof object>).forEach((key) => {
-    if (fields.includes(key.toString()) && !object[key]) {
+    if (
+      fields.includes(key.toString()) &&
+      !object[key] &&
+      key.toString() !== 'email' &&
+      isProperLength((object[key] as unknown) as string, get(schema, key))
+    ) {
       set(error, key, 'validation.required');
     } else if (
       EMAIL_FIELDS.includes(key.toString()) &&
@@ -303,6 +308,12 @@ const youthFormValidator = (formValues: FormValues): ValidationErrors => {
           age < youthProfileConstants.PROFILE_CREATION.AGE_ADULT &&
           !formValues[value]
         ) {
+          if (
+            EMAIL_FIELDS.includes(value) &&
+            !Validator.isEmail(((formValues[value] as unknown) as string) || '')
+          ) {
+            return set(errors, value, 'validation.email');
+          }
           return set(errors, value, 'validation.required');
         }
         // If values exist execute checks below, otherwise return


### PR DESCRIPTION
This change should fix the last bug described [here](https://helsinkisolutionoffice.atlassian.net/browse/YM-21). Entering a value and then removing would leave empty string as a value and it would pass previous checks inside `validateObject` function. 

Additional guardians email field would always throw `validation.email`.  I added this same logic to first guardian, so error messages are aligned.
