### PR TITLE
YM-348 | Fix layout breaking

### DIFF
--- a/src/pages/youthProfiles/form/YouthProfileForm.module.css
+++ b/src/pages/youthProfiles/form/YouthProfileForm.module.css
@@ -59,7 +59,8 @@
 }
 
 .additionalContactDescription {
-  margin-bottom: calc(var(--spacing-xxs) * -1);
+  margin-top: var(--spacing-l);
+  margin-bottom: calc(var(--spacing-s) * -1);
 }
 
 @media (min-width: 722px) {

--- a/src/pages/youthProfiles/form/YouthProfileForm.tsx
+++ b/src/pages/youthProfiles/form/YouthProfileForm.tsx
@@ -374,12 +374,12 @@ const YouthProfileForm = (props: Props) => {
                 error={errors.approverPhone}
               />
             </div>
+            <FormGroupDescription
+              description={t('youthProfiles.addGuardiansText')}
+              name="additionalContactPersons"
+              className={styles.additionalContactDescription}
+            />
             <div className={styles.rowContainer}>
-              <FormGroupDescription
-                description={t('youthProfiles.addGuardiansText')}
-                name="additionalContactPersons"
-                className={styles.additionalContactDescription}
-              />
               <YouthProfileArrayField
                 name="additionalContactPersons"
                 renderField={(name, index) => (


### PR DESCRIPTION
Move `FormGroupDescription` outside of `rowContainer` wrapper. With larger screens `flex:wrap` would but additional approver fields next to `FormGroupDescription` text. I also added little extra margin to top and bottom to isolate the text little better.