### PR TITLE
YM-382 | Improve search list e2e tests.

### DIFF
--- a/browser-tests/pages/youthInformationSelector.ts
+++ b/browser-tests/pages/youthInformationSelector.ts
@@ -2,4 +2,5 @@ import { Selector } from 'testcafe';
 
 export const youthInformationSelector = {
   basicInformationTitle: Selector('h3').withText('Perustiedot'),
+  backToSearchResults: Selector('button').withText('Takaisin hakutulokseen'),
 };

--- a/browser-tests/pages/youthListSelector.ts
+++ b/browser-tests/pages/youthListSelector.ts
@@ -2,7 +2,9 @@ import { Selector } from 'testcafe';
 
 export const youthListSelector = {
   firstName: Selector('input[id="firstName"]'),
+  lastName: Selector('input[id="lastName"]'),
   searchButton: Selector('button[class^="YouthList_search"]'),
   addNewButton: Selector('button[class^="YouthList_create"]'),
   dataGrid: Selector('div[class^="YouthList_dataGrid"]'),
+  selectTestProfile: Selector('td').withText('Existing'),
 };

--- a/browser-tests/youthListView.ts
+++ b/browser-tests/youthListView.ts
@@ -2,16 +2,28 @@ import { navigationSelector } from './pages/navigationSelector';
 import { login } from './util/login';
 import { testUrl } from './util/settings';
 import { youthListSelector } from './pages/youthListSelector';
+import { youthInformationSelector } from './pages/youthInformationSelector';
 
 fixture('Youth list view').page(testUrl());
 
-test('Test search funtionality', async (t) => {
+test('Test search functionality', async (t) => {
   await login(t);
 
   await t
     .click(navigationSelector.youthProfiles)
-    .typeText(youthListSelector.firstName, 'Testi')
+    .typeText(youthListSelector.firstName, 'Existing')
+    .typeText(youthListSelector.lastName, 'TestProfile')
     .click(youthListSelector.searchButton)
+    .expect(youthListSelector.dataGrid.exists)
+    .ok()
+    .click(youthListSelector.selectTestProfile)
+    .expect(youthInformationSelector.basicInformationTitle.exists)
+    .ok()
+    .click(youthInformationSelector.backToSearchResults)
+    .expect(youthListSelector.firstName.value)
+    .eql('Existing')
+    .expect(youthListSelector.lastName.value)
+    .eql('TestProfile')
     .expect(youthListSelector.dataGrid.exists)
     .ok();
 });


### PR DESCRIPTION
## Description
Improved search list `e2e` tests.
1) Search for profile that has a unique name
2) Test that search results appear
3) Test navigation to youth profile
4) Navigate back to search list, and test that search terms still exists and search is executed again 

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
All search list functionalities are now covered.

[YM-382](https://helsinkisolutionoffice.atlassian.net/browse/YM-382)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
`yarn browser-test` -> all tests pass.

## Manual Testing Instructions for Reviewers
1) Add values to `.env ` file (if you don't have these you can contact me):
- `REACT_APP_TESTING_USERNAME`
- `REACT_APP_TESTING_USERNAME_NO_ACCESS`
- `REACT_APP_TESTING_PASSWORD`

2) Login to [profile-admin](https://profiili-api.test.kuva.hel.ninja/admin/) and make sure "Ulla User" has no profile
3) Start local application `yarn start`
4) Run `yarn browser-test`
5) Delete the created profile to avoid unnecessary problems.

