### PR TITLE
YM-383, YM-384 |  E2e tests for editing profile information.

### DIFF
--- a/browser-tests/pages/registrationFormSelector.ts
+++ b/browser-tests/pages/registrationFormSelector.ts
@@ -18,8 +18,8 @@ export const registrationFormSelector = {
   schoolName: Selector('input[id="schoolName"]'),
   schoolClass: Selector('input[id="schoolClass"]'),
   languageFinnish: Selector('label').withText('Suomi'),
-  languageSwedish: Selector('label').withText('Englanti'),
-  languageEnglish: Selector('label').withText('Ruotsi'),
+  languageSwedish: Selector('label').withText('Ruotsi'),
+  languageEnglish: Selector('label').withText('Englanti'),
   photoUsageYes: Selector('label').withText('Kyllä'),
   photoUsageNo: Selector('label').withText('Ei'),
   approverFirstName: Selector('input[id="approverFirstName"]'),
@@ -32,6 +32,9 @@ export const registrationFormSelector = {
   )
     .withText('Poista')
     .nth(0),
+  additionalAddressMakePrimary: Selector('button').withText(
+    'Muuta ensisijaiseksi osoitteeksi'
+  ),
   additionalAddressAddress: Selector('input[id="addresses[0].address"]'),
   additionalAddressPostalCode: Selector('input[id="addresses[0].postalCode"]'),
   additionalAddressCity: Selector('input[id="addresses[0].city"]'),

--- a/browser-tests/pages/youthInformationSelector.ts
+++ b/browser-tests/pages/youthInformationSelector.ts
@@ -3,4 +3,26 @@ import { Selector } from 'testcafe';
 export const youthInformationSelector = {
   basicInformationTitle: Selector('h3').withText('Perustiedot'),
   backToSearchResults: Selector('button').withText('Takaisin hakutulokseen'),
+  editProfile: Selector('button').withText('Muokkaa'),
+  name: Selector('p').withText('Nimi').sibling('p'),
+  mainAddress: Selector('p').withText('Osoite').sibling('p').nth(0),
+  secondaryAddress: Selector('p').withText('Osoite').sibling('p').nth(1),
+  phone: Selector('p').withText('Puhelinnumero').sibling('p'),
+  languageAtHome: Selector('p').withText('Kotona puhuttu kieli').sibling('p'),
+  photoUsage: Selector('p').withText('Kuvauslupa').sibling('p'),
+  mainApproverName: Selector('p').withText('Nimi').sibling('p').nth(1),
+  mainApproverEmail: Selector('p').withText('Sähköposti').sibling('p').nth(1),
+  mainApproverPhone: Selector('p')
+    .withText('Puhelinnumero')
+    .sibling('p')
+    .nth(1),
+  secondaryApproverName: Selector('p').withText('Nimi').sibling('p').nth(2),
+  secondaryApproverEmail: Selector('p')
+    .withText('Sähköposti')
+    .sibling('p')
+    .nth(2),
+  secondaryApproverPhone: Selector('p')
+    .withText('Puhelinnumero')
+    .sibling('p')
+    .nth(2),
 };

--- a/browser-tests/util/registrationFormFillers.ts
+++ b/browser-tests/util/registrationFormFillers.ts
@@ -1,0 +1,100 @@
+import { registrationFormSelector } from '../pages/registrationFormSelector';
+import { youthInformationSelector } from '../pages/youthInformationSelector';
+
+export const changeAddresses = async (
+  t: TestController,
+  address: string[],
+  postalCode: string[],
+  city: string[]
+) => {
+  await t
+    .selectText(registrationFormSelector.primaryAddress)
+    .typeText(registrationFormSelector.primaryAddress, address[0])
+    .selectText(registrationFormSelector.primaryPostalCode)
+    .typeText(registrationFormSelector.primaryPostalCode, postalCode[0])
+    .selectText(registrationFormSelector.primaryCity)
+    .typeText(registrationFormSelector.primaryCity, city[0]);
+
+  await t
+    .selectText(registrationFormSelector.additionalAddressAddress)
+    .typeText(registrationFormSelector.additionalAddressAddress, address[1])
+    .selectText(registrationFormSelector.additionalAddressPostalCode)
+    .typeText(
+      registrationFormSelector.additionalAddressPostalCode,
+      postalCode[1]
+    )
+    .selectText(registrationFormSelector.additionalAddressCity)
+    .typeText(registrationFormSelector.additionalAddressCity, city[1]);
+};
+
+export const changeApprovers = async (
+  t: TestController,
+  firstName: string[],
+  lastName: string,
+  email: string[],
+  phone: string
+) => {
+  await t
+    .selectText(registrationFormSelector.approverFirstName)
+    .typeText(registrationFormSelector.approverFirstName, firstName[0])
+    .selectText(registrationFormSelector.approverLastName)
+    .typeText(registrationFormSelector.approverLastName, lastName)
+    .selectText(registrationFormSelector.approverEmail)
+    .typeText(registrationFormSelector.approverEmail, email[0])
+    .selectText(registrationFormSelector.approverPhone)
+    .typeText(registrationFormSelector.approverPhone, phone);
+
+  await t
+    .selectText(registrationFormSelector.additionalContactFirstName)
+    .typeText(registrationFormSelector.additionalContactFirstName, firstName[1])
+    .selectText(registrationFormSelector.additionalContactLastName)
+    .typeText(registrationFormSelector.additionalContactLastName, lastName)
+    .selectText(registrationFormSelector.additionalContactEmail)
+    .typeText(registrationFormSelector.additionalContactEmail, email[1])
+    .selectText(registrationFormSelector.additionalContactPhone)
+    .typeText(registrationFormSelector.additionalContactPhone, phone);
+};
+
+export const expectProfileInformation = async (
+  t: TestController,
+  name: string,
+  addresses: string[],
+  phone: string,
+  language: string,
+  photoUsage: string
+) => {
+  await t
+    .expect(youthInformationSelector.name.innerText)
+    .eql(name)
+    .expect(youthInformationSelector.mainAddress.innerText)
+    .eql(addresses[0])
+    .expect(youthInformationSelector.secondaryAddress.innerText)
+    .eql(addresses[1])
+    .expect(youthInformationSelector.phone.innerText)
+    .eql(phone)
+    .expect(youthInformationSelector.languageAtHome.innerText)
+    .eql(language)
+    .expect(youthInformationSelector.photoUsage.innerText)
+    .eql(photoUsage);
+};
+
+export const expectApprovers = async (
+  t: TestController,
+  names: string[],
+  emails: string[],
+  phones: string
+) => {
+  await t
+    .expect(youthInformationSelector.mainApproverName.innerText)
+    .eql(names[0])
+    .expect(youthInformationSelector.mainApproverEmail.innerText)
+    .eql(emails[0])
+    .expect(youthInformationSelector.mainApproverPhone.innerText)
+    .eql(phones)
+    .expect(youthInformationSelector.secondaryApproverName.innerText)
+    .eql(names[1])
+    .expect(youthInformationSelector.secondaryApproverEmail.innerText)
+    .eql(emails[1])
+    .expect(youthInformationSelector.secondaryApproverPhone.innerText)
+    .eql(phones);
+};

--- a/browser-tests/youthProfileInformationView.ts
+++ b/browser-tests/youthProfileInformationView.ts
@@ -120,4 +120,20 @@ test('Edit youths profile information', async (t) => {
     ['ursula.user@mailinator.com', 'uriel.user@mailinator.com'],
     '0501234567'
   );
+
+  // One last round, test "Make address primary" functionality
+  await t
+    .click(youthInformationSelector.editProfile)
+    .click(registrationFormSelector.additionalAddressMakePrimary)
+    .click(registrationFormSelector.submitButton)
+    .expect(youthInformationSelector.mainAddress.innerText)
+    .eql('Test street 202, 00200, Helsinki, Suomi');
+
+  // And change address back
+  await t
+    .click(youthInformationSelector.editProfile)
+    .click(registrationFormSelector.additionalAddressMakePrimary)
+    .click(registrationFormSelector.submitButton)
+    .expect(youthInformationSelector.mainAddress.innerText)
+    .eql('Test street 101, 00200, Helsinki, Ruotsi');
 });

--- a/browser-tests/youthProfileInformationView.ts
+++ b/browser-tests/youthProfileInformationView.ts
@@ -1,0 +1,123 @@
+import { login } from './util/login';
+import { testUrl } from './util/settings';
+import {
+  changeAddresses,
+  changeApprovers,
+  expectProfileInformation,
+  expectApprovers,
+} from './util/registrationFormFillers';
+import { youthInformationSelector } from './pages/youthInformationSelector';
+import { registrationFormSelector } from './pages/registrationFormSelector';
+
+// Enter straight to youth's information with url. This simulates behaviour when staff member reads youth's QR-code.
+// TODO: Figure out better way to implement ID
+fixture('View and edit').page(
+  `${testUrl().trim()}youthProfiles/UHJvZmlsZU5vZGU6M2Y5ZDkzZTEtODEzMi00NzA4LWJmOGQtYTY2ODgyYWQyNjAy/show`
+);
+
+test('Edit youths profile information', async (t) => {
+  await login(t);
+  await t.click(youthInformationSelector.editProfile);
+
+  // Change all of the profile information
+  await t
+    .selectText(registrationFormSelector.firstName)
+    .typeText(registrationFormSelector.firstName, 'TestProfile')
+    .selectText(registrationFormSelector.lastName)
+    .typeText(registrationFormSelector.lastName, 'Existing');
+
+  await changeAddresses(
+    t,
+    ['User street 303', 'User street 404'],
+    ['12345', '54321'],
+    ['Espoo', 'Vantaa']
+  );
+
+  await t
+    .selectText(registrationFormSelector.phone)
+    .typeText(registrationFormSelector.phone, '7654321050')
+    .click(registrationFormSelector.languageFinnish)
+    .click(registrationFormSelector.photoUsageYes);
+
+  await changeApprovers(
+    t,
+    ['Tim', 'Tina'],
+    'Tester',
+    ['tim@tester.fi', 'tina@tester.fi'],
+    '7654321050'
+  );
+
+  await t.click(registrationFormSelector.submitButton);
+
+  // Make sure values changed
+  await expectProfileInformation(
+    t,
+    'TestProfile Existing',
+    [
+      'User street 303, 12345, Espoo, Ruotsi',
+      'User street 404, 54321, Vantaa, Suomi',
+    ],
+    '7654321050',
+    'Suomi',
+    'Kyllä'
+  );
+
+  await expectApprovers(
+    t,
+    ['Tim Tester', 'Tina Tester'],
+    ['tim@tester.fi', 'tina@tester.fi'],
+    '7654321050'
+  );
+
+  // Change values back, this way we can always make sure values are changed
+  await t.click(youthInformationSelector.editProfile);
+
+  await t
+    .selectText(registrationFormSelector.firstName)
+    .typeText(registrationFormSelector.firstName, 'Existing')
+    .selectText(registrationFormSelector.lastName)
+    .typeText(registrationFormSelector.lastName, 'TestProfile');
+
+  await changeAddresses(
+    t,
+    ['Test street 101', 'Test street 202'],
+    ['00200', '00200'],
+    ['Helsinki', 'Helsinki']
+  );
+
+  await t
+    .selectText(registrationFormSelector.phone)
+    .typeText(registrationFormSelector.phone, '0501234567')
+    .click(registrationFormSelector.languageEnglish)
+    .click(registrationFormSelector.photoUsageNo);
+
+  await changeApprovers(
+    t,
+    ['Ursula', 'Uriel'],
+    'User',
+    ['ursula.user@mailinator.com', 'uriel.user@mailinator.com'],
+    '0501234567'
+  );
+
+  await t.click(registrationFormSelector.submitButton);
+
+  // Make sure values changed
+  await expectProfileInformation(
+    t,
+    'Existing TestProfile',
+    [
+      'Test street 101, 00200, Helsinki, Ruotsi',
+      'Test street 202, 00200, Helsinki, Suomi',
+    ],
+    '0501234567',
+    'Englanti',
+    'Ei'
+  );
+
+  await expectApprovers(
+    t,
+    ['Ursula User', 'Uriel User'],
+    ['ursula.user@mailinator.com', 'uriel.user@mailinator.com'],
+    '0501234567'
+  );
+});


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
More `e2e` - tests. After these all main functionalities are covered. 
I made a little risky decision with `youthProfileInformationView`, it enter's one of the youth's profiles using existing ID (ID is hard coded...). Testing this functionality is a must, it simulates behaviour when staff member reads youth's QR code. 

I left a TODO comment to figure it out at some point.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->
Adds more test coverage. I found one bug while writing these tests. It's documented [here](https://helsinkisolutionoffice.atlassian.net/browse/YM-408)

[YM-383](https://helsinkisolutionoffice.atlassian.net/browse/YM-383)
[YM-384](https://helsinkisolutionoffice.atlassian.net/browse/YM-384)

## How Has This Been Tested?
<!-- Explain what automated and manual testing approaches you have used -->
`yarn browser-test` -> all tests pass.

## Manual Testing Instructions for Reviewers
1) Add values to `.env ` file (if you don't have these you can contact me):
- `REACT_APP_TESTING_USERNAME`
- `REACT_APP_TESTING_USERNAME_NO_ACCESS`
- `REACT_APP_TESTING_PASSWORD`

2) Login to [profile-admin](https://profiili-api.test.kuva.hel.ninja/admin/) and make sure "Ulla User" has no profile
3) Start local application `yarn start`
4) Run `yarn browser-test`
5) Delete the created profile (Ulla User) to avoid unnecessary problems.
 **IMPORTANT: DO NOT DELETE PROFILE "Existing TestProfile"**
