### PR TITLE
YM-340 | Run browser tests in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# browser test screenshots on error
+screenshots

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,9 @@ jobs:
       name: 'Run (test) build'
       if: branch IN (master, develop)
       script: yarn build
+    - stage: 'Browser test'
+      name: 'Run browser tests'
+      if: type = cron
+      script: yarn browser-test:ci
 after_success:
   - ./node_modules/.bin/codecov < coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Browser test are written in TypeScript with [TestCafe](https://devexpress.github
 Make sure the project is running locally and required env variables are set (you can contact Santtu Tuovinen for these).
 Execute tests with `yarn browser-test`
 
+Browser tests are ran configured to run in Travis against the cron event with the `browser-test:ci` command. Cron is configured to run once a day.
+
 ## Known issues
 https://github.com/City-of-Helsinki/youth-membership-admin-ui/issues
 

--- a/browser-tests/pages/loginSelector.ts
+++ b/browser-tests/pages/loginSelector.ts
@@ -6,5 +6,7 @@ export const loginSelector = {
   helUsername: Selector('#username'),
   helPassword: Selector('#password'),
   helLogin: Selector('#kc-login'),
-  noAccess: Selector('p[class^="makeStyles-description"]'),
+  noAccess: Selector('p').withText(
+    'Sinulla ei ole oikeuksia käyttää tätä järjestelmää'
+  ),
 };

--- a/browser-tests/pages/registrationFormSelector.ts
+++ b/browser-tests/pages/registrationFormSelector.ts
@@ -2,7 +2,7 @@ import { Selector } from 'testcafe';
 
 export const registrationFormSelector = {
   inputErrors: Selector('div[class^="TextInput-module_helperText"]'),
-  birthDateError: Selector('p[class^="makeStyles-errorHelper"]'),
+  birthDateError: Selector('.MuiBox-root > p').withText('Vaadittu'),
   firstName: Selector('input[id="firstName"]'),
   lastName: Selector('input[id="lastName"]'),
   primaryCountry: Selector('select[name="primaryAddress.countryCode"]'),

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "eject": "react-scripts eject",
     "lint": "eslint --ext js,ts,tsx src",
     "codegen": "apollo client:codegen --target=typescript --no-addTypename --outputFlat src/graphql/generatedTypes.ts --useReadOnlyTypes --endpoint=https://profiili-api.test.kuva.hel.ninja/graphql/",
-    "browser-test": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/"
+    "browser-test": "testcafe \"chrome --window-size='1920,1080'\" browser-tests/",
+    "browser-test:ci": "testcafe \"chrome:headless --disable-gpu --window-size='1920,1080'\" browser-tests/ -s takeOnFails=true"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Description
These changes configure browser tests to run on Travis cron jobs.

I had to modify one selector, because it didn't work for a production version of the build where `makeStyles` classes are shortened.

I also configured the environment and cron jobs in Travis against `develop`.

## Context

[YM-340](https://helsinkisolutionoffice.atlassian.net/browse/YM-340)

## How Has This Been Tested?
I've ran browser tests locally against the current staging version with both commands.

I configured cron to run against this branch and checked that it passed.

## Manual Testing Instructions for Reviewers

No real manual steps, but you could check out the cron test ran against this branch:
* https://travis-ci.com/github/City-of-Helsinki/youth-membership-admin-ui/jobs/428566146

