### PR TITLE
Chore | Fix browser test by adding missing slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+[![codecov](https://codecov.io/gh/City-of-Helsinki/youth-membership-admin-ui/branch/develop/graph/badge.svg)](https://codecov.io/gh/City-of-Helsinki/youth-membership-admin-ui)
+![Build status](https://github.com/City-of-Helsinki/youth-membership-admin-ui/workflows/CI/badge.svg?branch=develop)
+![Browser tests](https://github.com/City-of-Helsinki/youth-membership-admin-ui/workflows/Browser%20tests/badge.svg?branch=develop)
 
 ## Youth-membership-admin
 Staff interface for Youth membership
@@ -7,7 +9,7 @@ Staff interface for Youth membership
 
 Test: https://jassari-admin.test.kuva.hel.ninja/
 
-Production: -
+Production: https://jassari-admin.hel.fi/
 
 ### Issues board
 
@@ -43,6 +45,12 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 ### `yarn codegen`
 
 Generate static types for GraphQL queries by using the schema from the backend server.
+
+### `yarn browser-test`
+
+The `ci` variant of `browser-test` is ran against a headless browser, making it suitable for CI environments.
+
+Browser tests are configured to run with GitHub actions during each weekday with the `browser-test:ci` command.
 
 ## Setting up development environment locally with docker
 

--- a/browser-tests/youthProfileInformationView.ts
+++ b/browser-tests/youthProfileInformationView.ts
@@ -17,7 +17,7 @@ import { registrationFormSelector } from './pages/registrationFormSelector';
 // Enter straight to youth's information with url. This simulates behaviour when staff member reads youth's QR-code.
 // TODO: Figure out better way to implement ID
 fixture('View and edit').page(
-  `${testUrl().trim()}youthProfiles/${userYouthProfileId()}/show`
+  `${testUrl().trim()}/youthProfiles/${userYouthProfileId()}/show`
 );
 
 test('Edit youths profile information', async (t) => {


### PR DESCRIPTION
## Description
A missing slash caused the the domain name to be incorrectly formatted.

You can check that browser tests now pass here: https://github.com/City-of-Helsinki/youth-membership-admin-ui/runs/1457649521?check_suite_focus=true

I ran browser tests manually against this branch, meaning that I used the workflow configuration from this branch.

I also updated the readme.
