### PR TITLE
Chore | Use public Jassari API

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -34,7 +34,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE: 'https://api.hel.fi/auth/jassariapi'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassari-admin-prod'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid $DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE $DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE'
-          DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://jassari-federation.prod.kuva.hel.ninja/'
+          DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://jassari.api.hel.fi'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://13e1b97fb11c4d10976a27675061c6c3@sentry.hel.ninja/60'
           DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari-admin.hel.fi/'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ build-production:
     DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE: 'https://api.hel.fi/auth/jassariapi'
     DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassari-admin-prod'
     DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid $DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE $DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE'
-    DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://jassari-federation.prod.kuva.hel.ninja/'
+    DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://jassari.api.hel.fi'
     DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://13e1b97fb11c4d10976a27675061c6c3@sentry.hel.ninja/60'
     DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari-admin.hel.fi/'
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Use GitHub actions instead of Travis
 - Use federated youth membership service
+- Use public address for Jassari API
 
 ## [1.2.0] - 2020-11-03
 ### Added


### PR DESCRIPTION
## Description

Uses the public API for Jassari. The non-public endpoint may not be enabled for all users.
