### PR TITLE
FIX | Use the same tunnistamo as the backend does

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT=3001
-REACT_APP_OIDC_AUTHORITY=https://api.hel.fi/sso-test/
+REACT_APP_OIDC_AUTHORITY=https://tunnistamo.test.kuva.hel.ninja
 REACT_APP_PROFILE_AUDIENCE=https://api.hel.fi/auth/helsinkiprofile
 REACT_APP_JASSARI_AUDIENCE=https://api.hel.fi/auth/jassariapi
 REACT_APP_OIDC_CLIENT_ID=https://api.hel.fi/auth/jassari-admin-ui

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           DOCKER_IMAGE_NAME: ${{ env.REPO_NAME }}-staging
           DOCKER_BUILD_ARG_REACT_APP_ENVIRONMENT: 'staging'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://api.hel.fi/sso-test/'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_AUTHORITY: 'https://tunnistamo.${{ env.BASE_DOMAIN }}/'
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE: 'https://api.hel.fi/auth/helsinkiprofile'
           DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE: 'https://api.hel.fi/auth/jassariapi'
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://api.hel.fi/auth/jassari-admin-ui'

--- a/src/auth/__tests__/__snapshots__/authService.test.js.snap
+++ b/src/auth/__tests__/__snapshots__/authService.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`authService fetchApiTokens should call axios.get with the right arguments 1`] = `
 Array [
-  "https://api.hel.fi/sso-test/api-tokens/",
+  "https://tunnistamo.test.kuva.hel.ninjaapi-tokens/",
   Object {
-    "baseURL": "https://api.hel.fi/sso-test/",
+    "baseURL": "https://tunnistamo.test.kuva.hel.ninja",
     "headers": Object {
       "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",
     },


### PR DESCRIPTION
## Description

Currently the backend uses Kuva's Tunnistamo and this application uses Kanlia's Tunnistamo. It means that the token we receive when authenticating with Kanslia's Tunnistamo, will not be consider valid by Kuvaäs Tunnistamo.