### PR TITLE
Fix production build

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,8 +35,7 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE: ${{ env.PROFILE_AUDIENCE }}
           DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE: ${{ env.JASSARI_AUDIENCE }}
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassari-admin-prod'
-          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid ${{ env.PROFILE_AUDIENCE }} ${{ env.JASSARI_AUDIENCE }}'
-          DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://jassari.api.hel.fi'
+          DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://api.hel.fi/profiili/graphql/'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://13e1b97fb11c4d10976a27675061c6c3@sentry.hel.ninja/60'
           DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari-admin.hel.fi/'
 


### PR DESCRIPTION
Reverts the production config to use older helsinki profile backend. These variables names were a bit different than I remembered, but I think I changed the correct ones.
