### PR TITLE
Chore | Update changelog and revert earlier backend url changes.

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -35,7 +35,8 @@ jobs:
           DOCKER_BUILD_ARG_REACT_APP_PROFILE_AUDIENCE: ${{ env.PROFILE_AUDIENCE }}
           DOCKER_BUILD_ARG_REACT_APP_JASSARI_AUDIENCE: ${{ env.JASSARI_AUDIENCE }}
           DOCKER_BUILD_ARG_REACT_APP_OIDC_CLIENT_ID: 'https://id.hel.fi/auth/clients/jassari-admin-prod'
-          DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://api.hel.fi/profiili/graphql/'
+          DOCKER_BUILD_ARG_REACT_APP_OIDC_SCOPE: 'openid ${{ env.PROFILE_AUDIENCE }} ${{ env.JASSARI_AUDIENCE }}'
+          DOCKER_BUILD_ARG_REACT_APP_JASSARI_FEDERATION_GRAPHQL: 'https://jassari.api.hel.fi'
           DOCKER_BUILD_ARG_REACT_APP_SENTRY_DSN: 'https://13e1b97fb11c4d10976a27675061c6c3@sentry.hel.ninja/60'
           DOCKER_BUILD_ARG_REACT_APP_BASE_URL: 'https://jassari-admin.hel.fi/'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use federated youth membership service
 - Use public address for Jassari API
 
+## [1.2.2] - 2020-02-01
+- Re-release on v.1.2.0 with backend pointing to profile.
+
+## [1.2.1] - 2020-02-01
+- Re-release on v.1.2.0 with production GitHub actions workflow.
+
 ## [1.2.0] - 2020-11-03
 ### Added
 - E2E tests added for registering, searching, viewing and modifying youths


### PR DESCRIPTION
Updated documentation relating to releases.

Reverted earlier changes where production workflow's url's were pointed to helsinki profiles backend.