### PR TITLE
YM-408 | Fix non-required fields being unclearable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Use federated youth membership service
 - Use public address for Jassari API
 
+### Fixed
+- Non-required youth profile fields can be cleared
+
 ## [1.2.2] - 2020-02-01
 - Re-release on v.1.2.0 with backend pointing to profile.
 

--- a/src/pages/youthProfiles/helpers/__tests__/youthProfileMutationVariables.test.js
+++ b/src/pages/youthProfiles/helpers/__tests__/youthProfileMutationVariables.test.js
@@ -1,0 +1,19 @@
+import { getUpdateProfilesVariables } from '../youthProfileMutationVariables';
+
+describe('youthProfileMutationVariables', () => {
+  it('should return empty values for unchanged fields', () => {
+    const schoolClass = undefined;
+
+    expect(
+      getUpdateProfilesVariables({
+        schoolClass,
+        addresses: [],
+        additionalContactPersons: [],
+        primaryAddress: {
+          id: '1',
+        },
+        birthDate: '1956-03-01',
+      }).youthProfileInput.youthProfile.schoolClass
+    ).toEqual('');
+  });
+});

--- a/src/pages/youthProfiles/helpers/youthProfileMutationVariables.ts
+++ b/src/pages/youthProfiles/helpers/youthProfileMutationVariables.ts
@@ -57,13 +57,13 @@ const getYouthProfile = (formValues: FormValues, profile?: Profile) => {
 
   return {
     birthDate: format(new Date(formValues.birthDate), 'yyyy-MM-dd'),
-    schoolName: formValues.schoolName,
-    schoolClass: formValues.schoolClass,
-    approverFirstName: formValues.approverFirstName,
-    approverLastName: formValues.approverLastName,
-    approverPhone: formValues.approverPhone,
-    approverEmail: formValues.approverEmail,
-    languageAtHome: formValues.languageAtHome,
+    schoolName: formValues.schoolName || '',
+    schoolClass: formValues.schoolClass || '',
+    approverFirstName: formValues.approverFirstName || '',
+    approverLastName: formValues.approverLastName || '',
+    approverPhone: formValues.approverPhone || '',
+    approverEmail: formValues.approverEmail || '',
+    languageAtHome: formValues.languageAtHome || '',
     photoUsageApproved: formValues.photoUsageApproved === 'true',
     ...additionalContactPersonChanges,
   };


### PR DESCRIPTION
## Description

Fix behaviour where the user could not set a non-required field as empty (for instance the schoolClass field).

This was because the values sent to the server were based on the form values provided by react-admin, and react-final-form within it. In these values empty values were defined as undefined, which meant that they were omitted entirely from the object sent to the server.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-408](https://helsinkisolutionoffice.atlassian.net/browse/YM-408)

## How Has This Been Tested?

I added a unit test that checks that empty values receive an empty default value.

## Manual Testing Instructions for Reviewers
<!-- Make it easy for reviewers to test your changes by providing instructions -->

## Screenshots
<!-- Add screenshots if appropriate -->
