### PR TITLE
YM-502 | Change label Profile language to Preferred service language

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 PORT=3001
-REACT_APP_OIDC_AUTHORITY=https://tunnistamo.test.kuva.hel.ninja
+REACT_APP_OIDC_AUTHORITY=https://tunnistamo.test.kuva.hel.ninja/
 REACT_APP_PROFILE_AUDIENCE=https://api.hel.fi/auth/helsinkiprofile
 REACT_APP_JASSARI_AUDIENCE=https://api.hel.fi/auth/jassariapi
 REACT_APP_OIDC_CLIENT_ID=https://api.hel.fi/auth/jassari-admin-ui

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
+### Changed
+- Label "Profile language" to "Preferred service language"
+
 ## [1.3.1] - 2020-02-18
 
 ### Fixed

--- a/src/auth/__tests__/__snapshots__/authService.test.js.snap
+++ b/src/auth/__tests__/__snapshots__/authService.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`authService fetchApiTokens should call axios.get with the right arguments 1`] = `
 Array [
-  "https://tunnistamo.test.kuva.hel.ninjaapi-tokens/",
+  "https://tunnistamo.test.kuva.hel.ninja/api-tokens/",
   Object {
-    "baseURL": "https://tunnistamo.test.kuva.hel.ninja",
+    "baseURL": "https://tunnistamo.test.kuva.hel.ninja/",
     "headers": Object {
       "Authorization": "bearer db237bc3-e197-43de-8c86-3feea4c5f886",
     },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,7 +25,7 @@
     "photoUsageDenied": "No",
     "photoUsageHelpText": "Pictures of my child can be taken and used for internal and external communications in the City of Helsinki.",
     "language": "Language",
-    "profileLanguage": "Profile language",
+    "profileLanguage": "Preferred service language",
     "address": "Address",
     "streetAddress": "Street address",
     "city": "City",

--- a/src/i18n/fi.json
+++ b/src/i18n/fi.json
@@ -25,7 +25,7 @@
     "photoUsageDenied": "Ei",
     "photoUsageHelpText": "Lapsestani saa ottaa kuvia ja niitä saa käyttää Helsingin kaupungin sisäisessä ja ulkoisessa viestinnässä.",
     "language": "Kieli",
-    "profileLanguage": "Profiilin kieli",
+    "profileLanguage": "Ensisijainen asiointikieli",
     "address": "Osoite",
     "streetAddress": "Katuosoite",
     "city": "Kaupunki",

--- a/src/i18n/sv.json
+++ b/src/i18n/sv.json
@@ -25,7 +25,7 @@
     "photoUsageDenied": "Nej",
     "photoUsageHelpText": "Bilder av mitt barn kan tas och användas för intern och extern kommunikation i Helsingfors stad.",
     "language": "Språk",
-    "profileLanguage": "Profilspråk",
+    "profileLanguage": "Prefererat servicespråk",
     "address": "adress",
     "streetAddress": "Gatuadress",
     "city": "Stad",


### PR DESCRIPTION
## Description

Changes the label of the field profileLanguage to "Preferred service language".

Also fixes the default environment. It was missing an ending slash which caused the Tunnistamo integration to fail.

## Context
<!-- Why is this change required? What problem does it solve? -->
<!-- Leave a link to the Jira ticket for posterity. -->

[YM-502](https://helsinkisolutionoffice.atlassian.net/browse/YM-502)

## How Has This Been Tested?

I've tested the change by hand.
