### PR TITLE
Fix browser tests

### DIFF
--- a/.github/workflows/browser-test.yml
+++ b/.github/workflows/browser-test.yml
@@ -41,3 +41,9 @@ jobs:
         BROWSER_TESTING_EXISTING_USER_YOUTH_PROFILE_ID: ${{ secrets.BROWSER_TESTING_EXISTING_USER_YOUTH_PROFILE_ID }}
         BROWSER_TESTING_EXISTING_USER_FIRST_NAME: ${{ secrets.BROWSER_TESTING_EXISTING_USER_FIRST_NAME }}
         BROWSER_TESTING_EXISTING_USER_LAST_NAME: ${{ secrets.BROWSER_TESTING_EXISTING_USER_LAST_NAME }}
+    - name: Upload screenshots of failed tests
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: screenshots
+        path: screenshots/

--- a/browser-tests/pages/registrationFormSelector.ts
+++ b/browser-tests/pages/registrationFormSelector.ts
@@ -1,5 +1,7 @@
 import { Selector } from 'testcafe';
 
+const languageAtHome = Selector('select[name="languageAtHome"]');
+
 export const registrationFormSelector = {
   inputErrors: Selector('div[class^="TextInput-module_helperText"]'),
   birthDateError: Selector('.MuiBox-root > p').withText('Vaadittu'),
@@ -17,9 +19,8 @@ export const registrationFormSelector = {
   birthDateYear: Selector('input[id="year"]'),
   schoolName: Selector('input[id="schoolName"]'),
   schoolClass: Selector('input[id="schoolClass"]'),
-  languageFinnish: Selector('label').withText('Suomi'),
-  languageSwedish: Selector('label').withText('Ruotsi'),
-  languageEnglish: Selector('label').withText('Englanti'),
+  languageAtHome,
+  languageAtHomeOption: languageAtHome.find('option'),
   photoUsageYes: Selector('label').withText('Kyllä'),
   photoUsageNo: Selector('label').withText('Ei'),
   approverFirstName: Selector('input[id="approverFirstName"]'),

--- a/browser-tests/pages/youthInformationSelector.ts
+++ b/browser-tests/pages/youthInformationSelector.ts
@@ -8,7 +8,9 @@ export const youthInformationSelector = {
   mainAddress: Selector('p').withText('Osoite').sibling('p').nth(0),
   secondaryAddress: Selector('p').withText('Osoite').sibling('p').nth(1),
   phone: Selector('p').withText('Puhelinnumero').sibling('p'),
-  languageAtHome: Selector('p').withText('Kotona puhuttu kieli').sibling('p'),
+  languageAtHome: Selector('p')
+    .withText('Ensisijainen yhteydenottokieli')
+    .sibling('p'),
   photoUsage: Selector('p').withText('Kuvauslupa').sibling('p'),
   mainApproverName: Selector('p').withText('Nimi').sibling('p').nth(1),
   mainApproverEmail: Selector('p').withText('Sähköposti').sibling('p').nth(1),

--- a/browser-tests/registrationView.ts
+++ b/browser-tests/registrationView.ts
@@ -75,15 +75,18 @@ test('Fill in the form and submit', async (t) => {
   await t
     .typeText(registrationFormSelector.schoolName, 'TestiKoulu')
     .typeText(registrationFormSelector.schoolClass, '1C')
-    .click(registrationFormSelector.languageEnglish)
-    .click(registrationFormSelector.languageSwedish)
-    .click(registrationFormSelector.languageFinnish)
     .click(registrationFormSelector.photoUsageYes)
     .click(registrationFormSelector.photoUsageNo)
     .typeText(registrationFormSelector.approverFirstName, 'Unique')
     .typeText(registrationFormSelector.approverLastName, 'User')
     .typeText(registrationFormSelector.approverEmail, 'unique@user.fi')
-    .typeText(registrationFormSelector.approverPhone, '0501234567');
+    .typeText(registrationFormSelector.approverPhone, '0501234567')
+    .click(registrationFormSelector.languageAtHome)
+    .click(registrationFormSelector.languageAtHomeOption.withText('Englanti'))
+    .click(registrationFormSelector.languageAtHome)
+    .click(registrationFormSelector.languageAtHomeOption.withText('Ruotsi'))
+    .click(registrationFormSelector.languageAtHome)
+    .click(registrationFormSelector.languageAtHomeOption.withText('Suomi'));
 
   // Add, remove and fill additional address
   await t

--- a/browser-tests/util/login.ts
+++ b/browser-tests/util/login.ts
@@ -8,7 +8,9 @@ export const login = async (t: TestController) => {
     .click(loginSelector.helLoginLink)
     .typeText(loginSelector.helUsername, username())
     .typeText(loginSelector.helPassword, password())
-    .click(loginSelector.helLogin)
-    .expect(navigationSelector.sideNavigation.exists)
-    .ok();
+    .click(loginSelector.helLogin);
+
+  await t.wait(1000);
+
+  await t.expect(navigationSelector.sideNavigation.exists).ok();
 };

--- a/browser-tests/youthProfileInformationView.ts
+++ b/browser-tests/youthProfileInformationView.ts
@@ -41,7 +41,8 @@ test('Edit youths profile information', async (t) => {
   await t
     .selectText(registrationFormSelector.phone)
     .typeText(registrationFormSelector.phone, '7654321050')
-    .click(registrationFormSelector.languageFinnish)
+    .click(registrationFormSelector.languageAtHome)
+    .click(registrationFormSelector.languageAtHomeOption.withText('Suomi'))
     .click(registrationFormSelector.photoUsageYes);
 
   await changeApprovers(
@@ -93,7 +94,8 @@ test('Edit youths profile information', async (t) => {
   await t
     .selectText(registrationFormSelector.phone)
     .typeText(registrationFormSelector.phone, '0501234567')
-    .click(registrationFormSelector.languageEnglish)
+    .click(registrationFormSelector.languageAtHome)
+    .click(registrationFormSelector.languageAtHomeOption.withText('Englanti'))
     .click(registrationFormSelector.photoUsageNo);
 
   await changeApprovers(

--- a/browser-tests/youthProfileInformationView.ts
+++ b/browser-tests/youthProfileInformationView.ts
@@ -17,7 +17,7 @@ import { registrationFormSelector } from './pages/registrationFormSelector';
 // Enter straight to youth's information with url. This simulates behaviour when staff member reads youth's QR-code.
 // TODO: Figure out better way to implement ID
 fixture('View and edit').page(
-  `${testUrl().trim()}/youthProfiles/${userYouthProfileId()}/show`
+  new URL(`/youthProfiles/${userYouthProfileId()}/show`, testUrl()).toString()
 );
 
 test('Edit youths profile information', async (t) => {


### PR DESCRIPTION
## Description

Browser tests have been working poorly in the past few months. I added more wait time after login which will hopefully help with the issues.

The recent changes to the language at home field also broke the test suite. Testcafe was also provided with an environment url that contained an ending slash, which broke redirection logic in some tests. I adjusted the URL creation logic so that the same url is returned regardless of an ending slash.

Test now pass here: https://github.com/City-of-Helsinki/youth-membership-admin-ui/actions/runs/708616409
